### PR TITLE
Fix multiply defined symbols for shared libraries.

### DIFF
--- a/opm/grid/common/MetisPartition.cpp
+++ b/opm/grid/common/MetisPartition.cpp
@@ -22,7 +22,7 @@
 
 #if HAVE_MPI // no code in this file without MPI, then skip includes.
 #include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/grid/common/ZoltanGraphFunctions.cpp>
+#include <opm/grid/common/ZoltanGraphFunctions.hpp>
 #include <opm/grid/common/MetisPartition.hpp>
 #include <opm/grid/utility/OpmWellType.hpp>
 #include <opm/grid/cpgrid/CpGridData.hpp>

--- a/opm/grid/common/ZoltanGraphFunctions.cpp
+++ b/opm/grid/common/ZoltanGraphFunctions.cpp
@@ -410,6 +410,15 @@ void setCpGridZoltanGraphFunctions(Zoltan_Struct *zz,
         Zoltan_Set_Edge_List_Multi_Fn(zz, getCpGridWellsEdgeList, graphPointer);
     }
 }
+// Explicit template instantiation for METIS
+#if HAVE_METIS
+template
+void fillNBORGIDForSpecificCellAndIncrementNeighborCounter(const Dune::CpGrid&, int, int*, int&, int*& nborGID);
+template
+void fillNBORGIDAndWeightsForSpecificCellAndIncrementNeighborCounterForGridWithWells(const CombinedGridWellGraph&, const int, int*, int&, int*&, int*);
+#endif
+
+
 } // end namespace cpgrid
 } // end namespace Dune
 #endif // defined(HAVE_ZOLTAN) && defined(HAVE_MPI)


### PR DESCRIPTION
When compiling shared libaries we got linker errors for functions that were defined multiple times.